### PR TITLE
Fix Handling of Extensions Managed by Editor

### DIFF
--- a/src/commands/install-extensions.ts
+++ b/src/commands/install-extensions.ts
@@ -55,7 +55,7 @@ export async function installExtensions(update: boolean = false): Promise<void> 
 	await fse.writeJSON(extensionsFileName, installedExtensions);
 }
 
-async function installExtension(extension: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string | null>, installedExtensions: Record<string, string | null>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{
+async function installExtension(extension: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string>, installedExtensions: Record<string, string>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{
 	debugChannel?.appendLine(`installing extension: ${extension}`);
 
 	if(extension.includes(':')) {
@@ -136,7 +136,7 @@ async function installExtension(extension: string, sources: Record<string, Sourc
 
 		await vscode.commands.executeCommand('workbench.extensions.installExtension', extension);
 
-		installedExtensions[extension] = null;
+		installedExtensions[extension] = '';
 		debugChannel?.appendLine('installed');
 	}
 	else {
@@ -144,7 +144,7 @@ async function installExtension(extension: string, sources: Record<string, Sourc
 	}
 } // }}}
 
-async function installGroup(groupName: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string | null>, installedExtensions: Record<string, string | null>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{
+async function installGroup(groupName: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string>, installedExtensions: Record<string, string>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{
 	debugChannel?.appendLine(`installing group: ${groupName}`);
 	if(!groups) {
 		debugChannel?.appendLine('no groups');

--- a/src/commands/install-extensions.ts
+++ b/src/commands/install-extensions.ts
@@ -55,7 +55,7 @@ export async function installExtensions(update: boolean = false): Promise<void> 
 	await fse.writeJSON(extensionsFileName, installedExtensions);
 }
 
-async function installExtension(extension: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string>, installedExtensions: Record<string, string>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{
+async function installExtension(extension: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string | null>, installedExtensions: Record<string, string | null>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{
 	debugChannel?.appendLine(`installing extension: ${extension}`);
 
 	if(extension.includes(':')) {
@@ -136,6 +136,7 @@ async function installExtension(extension: string, sources: Record<string, Sourc
 
 		await vscode.commands.executeCommand('workbench.extensions.installExtension', extension);
 
+		installedExtensions[extension] = null;
 		debugChannel?.appendLine('installed');
 	}
 	else {
@@ -143,7 +144,7 @@ async function installExtension(extension: string, sources: Record<string, Sourc
 	}
 } // }}}
 
-async function installGroup(groupName: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string>, installedExtensions: Record<string, string>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{
+async function installGroup(groupName: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string | null>, installedExtensions: Record<string, string | null>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{
 	debugChannel?.appendLine(`installing group: ${groupName}`);
 	if(!groups) {
 		debugChannel?.appendLine('no groups');

--- a/src/commands/uninstall-extensions.ts
+++ b/src/commands/uninstall-extensions.ts
@@ -69,7 +69,6 @@ async function uninstallExtension(extension: string, sources: Record<string, Sou
 		await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', extensionName);
 	}
 	else if(extension.includes('.')) {
-		// skip, managed by the editor
 		await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', extension);
 	}
 	else {

--- a/src/commands/uninstall-extensions.ts
+++ b/src/commands/uninstall-extensions.ts
@@ -70,6 +70,7 @@ async function uninstallExtension(extension: string, sources: Record<string, Sou
 	}
 	else if(extension.includes('.')) {
 		// skip, managed by the editor
+		await vscode.commands.executeCommand('workbench.extensions.uninstallExtension', extension);
 	}
 	else {
 		await updateGroup(extension, sources, groups, managedExtensions, debugChannel);


### PR DESCRIPTION
Currently, extensions managed by the editor aren't added to the list of extensions installed by vsix-manager.

Changes made in this PR will cause `vsix-manager` to add extensions managed by the editor to the list of installed extensions.

Furthermore, changes made in this PR will allow `vsix-manager` to uninstall extensions managed by the editor.

This might improve the experience of syncing extensions using `vsix-manager` alongside `sync-settings`