### PR TITLE
Keep Managed Extensions During Installation

### DIFF
--- a/src/commands/install-extensions.ts
+++ b/src/commands/install-extensions.ts
@@ -52,7 +52,7 @@ export async function installExtensions(update: boolean = false): Promise<void> 
 		}
 	}
 
-	await fse.writeJSON(extensionsFileName, installedExtensions);
+	await fse.writeJSON(extensionsFileName, { ...managedExtensions, ...installedExtensions });
 }
 
 async function installExtension(extension: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, editorExtensions: ExtensionList, managedExtensions: Record<string, string>, installedExtensions: Record<string, string>, debugChannel: vscode.OutputChannel | undefined, update: boolean): Promise<void> { // {{{


### PR DESCRIPTION
Whenever `installExtensions` is executed, all existing managed extensions are stripped from the extensions file.
This causes the extensions file, whenever a change happens (through `applyChanges` or a manual `installExtensions` invocation from the command palette), to be cleared.

Changes made in this PR fix this issue.