### PR TITLE
Fix Extension File Content In Uninstall Command

### DIFF
--- a/src/commands/uninstall-extensions.ts
+++ b/src/commands/uninstall-extensions.ts
@@ -36,7 +36,7 @@ export async function uninstallExtensions(): Promise<void> {
 		}
 	}
 
-	await fse.writeJSON(extensionsFileName, []);
+	await fse.writeJSON(extensionsFileName, {});
 }
 
 async function uninstallExtension(extension: string, sources: Record<string, Source> | undefined, groups: Record<string, string[]> | undefined, managedExtensions: Record<string, string>, debugChannel: vscode.OutputChannel | undefined): Promise<void> { // {{{


### PR DESCRIPTION
Currently, the `uninstallExtensions` command writes an empty array `[]` instead of an empty object `{}` to the extension file.
Changes made in this PR normalize the behavior in this point of view.