### PR TITLE
feat: add Forgejo source

### DIFF
--- a/src/sources/forgejo.ts
+++ b/src/sources/forgejo.ts
@@ -1,133 +1,17 @@
-import path from 'path';
 import process from 'process';
-import { pipeline } from 'stream/promises';
-import fse from 'fs-extra';
-import got from 'got';
-import semver from 'semver';
-import vscode from 'vscode';
-import { Forgejo, InstallResult, UpdateResult } from '../utils/types';
+import { Forgejo } from '../utils/types';
 
-async function download(name: string, version: string, source: Forgejo, url: string, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<void> { // {{{
-	debugChannel?.appendLine(`downloading version: ${version}`);
-
-	const fileName = path.join(temporaryDir, `${name}-${version}.vsix`);
-
-	const gotStream = got.stream.get(url, getHeaders(source));
-
-	const outStream = fse.createWriteStream(fileName);
-
-	await pipeline(gotStream, outStream);
-
-	await vscode.commands.executeCommand('workbench.extensions.installExtension', vscode.Uri.file(fileName));
-
-	await fse.unlink(fileName);
+export function getReleasesUrl(extensionName: string, source: Forgejo): string { // {{{
+	if(source.owner) {
+		return `${source.serviceUrl}/repos/${source.owner}/${extensionName}/releases`;
+	}
+	else {
+		return `${source.serviceUrl}/repos/${extensionName}/releases`;
+	}
 } // }}}
 
-export async function installForgejo(extensionName: string, extensionVersion: string | undefined, source: Forgejo, temporaryDir: string, enabled: boolean, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> { // {{{
-	const results = await got.get(getReleasesUrl(extensionName, source), getHeaders(source)).json();
-
-	if(!results || !Array.isArray(results)) {
-		return;
-	}
-
-	let name: string = '';
-	let version: string = '';
-	let url: string = '';
-
-	for(const result of results) {
-		if(result.assets) {
-			for(const asset of result.assets) {
-				const match = /^(.*?)-(\d+\.\d+\.\d+)\.vsix$/.exec(asset.name);
-
-				if(match) {
-					if(extensionVersion) {
-						if(extensionVersion === match[2]) {
-							name = match[1];
-							version = match[2];
-							url = asset.browser_download_url as string;
-						}
-					}
-					else if(!name) {
-						name = match[1];
-						version = match[2];
-						url = asset.browser_download_url as string;
-					}
-					else if(name === match[1] && semver.gt(match[2], version)) {
-						version = match[2];
-						url = asset.browser_download_url as string;
-					}
-				}
-			}
-		}
-	}
-
-	if(!version) {
-		return;
-	}
-
-	await download(name, version, source, url, temporaryDir, debugChannel);
-
-	return { name, version, enabled };
-} // }}}
-
-export async function updateForgejo(extensionName: string, currentVersion: string, source: Forgejo, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<UpdateResult> { // {{{
-	const results = await got.get(getReleasesUrl(extensionName, source), getHeaders(source)).json();
-
-	if(!results || !Array.isArray(results)) {
-		return;
-	}
-
-	let name: string = '';
-	let version: string = '';
-	let url: string = '';
-
-	for(const result of results) {
-		if(result.assets) {
-			for(const asset of result.assets) {
-				const match = /^(.*?)-(\d+\.\d+\.\d+)\.vsix$/.exec(asset.name);
-
-				if(match) {
-					if(!name) {
-						name = match[1];
-						version = match[2];
-						url = asset.browser_download_url as string;
-					}
-					else if(name === match[1] && semver.gt(match[2], version)) {
-						version = match[2];
-						url = asset.browser_download_url as string;
-					}
-				}
-			}
-		}
-	}
-
-	if(!version) {
-		return;
-	}
-
-	if(semver.lte(version, currentVersion)) {
-		return {
-			name,
-			version,
-			updated: false,
-		};
-	}
-
-	await download(name, version, source, url, temporaryDir, debugChannel);
-
-	return {
-		name,
-		version,
-		updated: true,
-	};
-} // }}}
-
-function getReleasesUrl(extensionName: string, source: Forgejo): string { // {{{
-	return `${source.serviceUrl}/repos/${source.owner}/${extensionName}/releases`;
-} // }}}
-
-function getHeaders(source: Forgejo): {} | undefined { // {{{
-	if(source?.token) {
+export function getHeaders(source: Forgejo): {} | undefined { // {{{
+	if(source.token) {
 		let token: string | undefined = '';
 
 		if(source.token.startsWith('env:')) {

--- a/src/sources/forgejo.ts
+++ b/src/sources/forgejo.ts
@@ -1,0 +1,150 @@
+import path from 'path';
+import process from 'process';
+import { pipeline } from 'stream/promises';
+import fse from 'fs-extra';
+import got from 'got';
+import semver from 'semver';
+import vscode from 'vscode';
+import { Forgejo, InstallResult, UpdateResult } from '../utils/types';
+
+async function download(name: string, version: string, source: Forgejo, url: string, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<void> { // {{{
+	debugChannel?.appendLine(`downloading version: ${version}`);
+
+	const fileName = path.join(temporaryDir, `${name}-${version}.vsix`);
+
+	const gotStream = got.stream.get(url, getHeaders(source));
+
+	const outStream = fse.createWriteStream(fileName);
+
+	await pipeline(gotStream, outStream);
+
+	await vscode.commands.executeCommand('workbench.extensions.installExtension', vscode.Uri.file(fileName));
+
+	await fse.unlink(fileName);
+} // }}}
+
+export async function installForgejo(extensionName: string, extensionVersion: string | undefined, source: Forgejo, temporaryDir: string, enabled: boolean, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> { // {{{
+	const results = await got.get(getReleasesUrl(extensionName, source), getHeaders(source)).json();
+
+	if(!results || !Array.isArray(results)) {
+		return;
+	}
+
+	let name: string = '';
+	let version: string = '';
+	let url: string = '';
+
+	for(const result of results) {
+		if(result.assets) {
+			for(const asset of result.assets) {
+				const match = /^(.*?)-(\d+\.\d+\.\d+)\.vsix$/.exec(asset.name);
+
+				if(match) {
+					if(extensionVersion) {
+						if(extensionVersion === match[2]) {
+							name = match[1];
+							version = match[2];
+							url = asset.browser_download_url as string;
+						}
+					}
+					else if(!name) {
+						name = match[1];
+						version = match[2];
+						url = asset.browser_download_url as string;
+					}
+					else if(name === match[1] && semver.gt(match[2], version)) {
+						version = match[2];
+						url = asset.browser_download_url as string;
+					}
+				}
+			}
+		}
+	}
+
+	if(!version) {
+		return;
+	}
+
+	await download(name, version, source, url, temporaryDir, debugChannel);
+
+	return { name, version, enabled };
+} // }}}
+
+export async function updateForgejo(extensionName: string, currentVersion: string, source: Forgejo, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<UpdateResult> { // {{{
+	const results = await got.get(getReleasesUrl(extensionName, source), getHeaders(source)).json();
+
+	if(!results || !Array.isArray(results)) {
+		return;
+	}
+
+	let name: string = '';
+	let version: string = '';
+	let url: string = '';
+
+	for(const result of results) {
+		if(result.assets) {
+			for(const asset of result.assets) {
+				const match = /^(.*?)-(\d+\.\d+\.\d+)\.vsix$/.exec(asset.name);
+
+				if(match) {
+					if(!name) {
+						name = match[1];
+						version = match[2];
+						url = asset.browser_download_url as string;
+					}
+					else if(name === match[1] && semver.gt(match[2], version)) {
+						version = match[2];
+						url = asset.browser_download_url as string;
+					}
+				}
+			}
+		}
+	}
+
+	if(!version) {
+		return;
+	}
+
+	if(semver.lte(version, currentVersion)) {
+		return {
+			name,
+			version,
+			updated: false,
+		};
+	}
+
+	await download(name, version, source, url, temporaryDir, debugChannel);
+
+	return {
+		name,
+		version,
+		updated: true,
+	};
+} // }}}
+
+function getReleasesUrl(extensionName: string, source: Forgejo): string { // {{{
+	return `${source.serviceUrl}/repos/${source.owner}/${extensionName}/releases`;
+} // }}}
+
+function getHeaders(source: Forgejo): {} | undefined { // {{{
+	if(source?.token) {
+		let token: string | undefined = '';
+
+		if(source.token.startsWith('env:')) {
+			token = process.env[source.token.slice(4)];
+		}
+		else {
+			token = source.token;
+		}
+
+		if(token) {
+			return {
+				headers: {
+					Authorization: `token ${token}`,
+				},
+			};
+		}
+	}
+
+	return undefined;
+} // }}}

--- a/src/sources/git.ts
+++ b/src/sources/git.ts
@@ -1,0 +1,122 @@
+import path from 'path';
+import { pipeline } from 'stream/promises';
+import fse from 'fs-extra';
+import got from 'got';
+import semver from 'semver';
+import vscode from 'vscode';
+import { GitConfig, GitService, InstallResult, UpdateResult } from '../utils/types';
+
+async function download(name: string, version: string, source: GitService | undefined, config: GitConfig, url: string, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<void> { // {{{
+	debugChannel?.appendLine(`downloading version: ${version}`);
+
+	const fileName = path.join(temporaryDir, `${name}-${version}.vsix`);
+
+	const gotStream = got.stream.get(url, config.getHeaders(source));
+
+	const outStream = fse.createWriteStream(fileName);
+
+	await pipeline(gotStream, outStream);
+
+	await vscode.commands.executeCommand('workbench.extensions.installExtension', vscode.Uri.file(fileName));
+
+	await fse.unlink(fileName);
+} // }}}
+
+export async function install(extensionName: string, extensionVersion: string | undefined, source: GitService | undefined, config: GitConfig, temporaryDir: string, enabled: boolean, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> { // {{{
+	const results = await got.get(config.getReleasesUrl(extensionName, source), config.getHeaders(source)).json();
+
+	if(!results || !Array.isArray(results)) {
+		return;
+	}
+
+	let name: string = '';
+	let version: string = '';
+	let url: string = '';
+
+	for(const result of results) {
+		if(result.assets) {
+			for(const asset of result.assets) {
+				const match = /^(.*?)-(\d+\.\d+\.\d+)\.vsix$/.exec(asset.name);
+
+				if(match) {
+					if(extensionVersion) {
+						if(extensionVersion === match[2]) {
+							name = match[1];
+							version = match[2];
+							url = asset.browser_download_url as string;
+						}
+					}
+					else if(!name) {
+						name = match[1];
+						version = match[2];
+						url = asset.browser_download_url as string;
+					}
+					else if(name === match[1] && semver.gt(match[2], version)) {
+						version = match[2];
+						url = asset.browser_download_url as string;
+					}
+				}
+			}
+		}
+	}
+
+	if(!version) {
+		return;
+	}
+
+	await download(name, version, source, config, url, temporaryDir, debugChannel);
+
+	return { name, version, enabled };
+} // }}}
+
+export async function update(extensionName: string, currentVersion: string, source: GitService | undefined, config: GitConfig, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<UpdateResult> { // {{{
+	const results = await got.get(config.getReleasesUrl(extensionName, source), config.getHeaders(source)).json();
+
+	if(!results || !Array.isArray(results)) {
+		return;
+	}
+
+	let name: string = '';
+	let version: string = '';
+	let url: string = '';
+
+	for(const result of results) {
+		if(result.assets) {
+			for(const asset of result.assets) {
+				const match = /^(.*?)-(\d+\.\d+\.\d+)\.vsix$/.exec(asset.name);
+
+				if(match) {
+					if(!name) {
+						name = match[1];
+						version = match[2];
+						url = asset.browser_download_url as string;
+					}
+					else if(name === match[1] && semver.gt(match[2], version)) {
+						version = match[2];
+						url = asset.browser_download_url as string;
+					}
+				}
+			}
+		}
+	}
+
+	if(!version) {
+		return;
+	}
+
+	if(semver.lte(version, currentVersion)) {
+		return {
+			name,
+			version,
+			updated: false,
+		};
+	}
+
+	await download(name, version, source, config, url, temporaryDir, debugChannel);
+
+	return {
+		name,
+		version,
+		updated: true,
+	};
+} // }}}

--- a/src/sources/github.ts
+++ b/src/sources/github.ts
@@ -1,128 +1,7 @@
-import path from 'path';
 import process from 'process';
-import { pipeline } from 'stream/promises';
-import fse from 'fs-extra';
-import got from 'got';
-import semver from 'semver';
-import vscode from 'vscode';
-import { GitHub, InstallResult, UpdateResult } from '../utils/types';
+import { GitHub } from '../utils/types';
 
-async function download(name: string, version: string, source: GitHub | undefined, url: string, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<void> { // {{{
-	debugChannel?.appendLine(`downloading version: ${version}`);
-
-	const fileName = path.join(temporaryDir, `${name}-${version}.vsix`);
-
-	const gotStream = got.stream.get(url, getHeaders(source));
-
-	const outStream = fse.createWriteStream(fileName);
-
-	await pipeline(gotStream, outStream);
-
-	await vscode.commands.executeCommand('workbench.extensions.installExtension', vscode.Uri.file(fileName));
-
-	await fse.unlink(fileName);
-} // }}}
-
-export async function installGitHub(extensionName: string, extensionVersion: string | undefined, source: GitHub | undefined, temporaryDir: string, enabled: boolean, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> { // {{{
-	const results = await got.get(getReleasesUrl(extensionName, source), getHeaders(source)).json();
-
-	if(!results || !Array.isArray(results)) {
-		return;
-	}
-
-	let name: string = '';
-	let version: string = '';
-	let url: string = '';
-
-	for(const result of results) {
-		if(result.assets) {
-			for(const asset of result.assets) {
-				const match = /^(.*?)-(\d+\.\d+\.\d+)\.vsix$/.exec(asset.name);
-
-				if(match) {
-					if(extensionVersion) {
-						if(extensionVersion === match[2]) {
-							name = match[1];
-							version = match[2];
-							url = asset.browser_download_url as string;
-						}
-					}
-					else if(!name) {
-						name = match[1];
-						version = match[2];
-						url = asset.browser_download_url as string;
-					}
-					else if(name === match[1] && semver.gt(match[2], version)) {
-						version = match[2];
-						url = asset.browser_download_url as string;
-					}
-				}
-			}
-		}
-	}
-
-	if(!version) {
-		return;
-	}
-
-	await download(name, version, source, url, temporaryDir, debugChannel);
-
-	return { name, version, enabled };
-} // }}}
-
-export async function updateGitHub(extensionName: string, currentVersion: string, source: GitHub | undefined, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<UpdateResult> { // {{{
-	const results = await got.get(getReleasesUrl(extensionName, source), getHeaders(source)).json();
-
-	if(!results || !Array.isArray(results)) {
-		return;
-	}
-
-	let name: string = '';
-	let version: string = '';
-	let url: string = '';
-
-	for(const result of results) {
-		if(result.assets) {
-			for(const asset of result.assets) {
-				const match = /^(.*?)-(\d+\.\d+\.\d+)\.vsix$/.exec(asset.name);
-
-				if(match) {
-					if(!name) {
-						name = match[1];
-						version = match[2];
-						url = asset.browser_download_url as string;
-					}
-					else if(name === match[1] && semver.gt(match[2], version)) {
-						version = match[2];
-						url = asset.browser_download_url as string;
-					}
-				}
-			}
-		}
-	}
-
-	if(!version) {
-		return;
-	}
-
-	if(semver.lte(version, currentVersion)) {
-		return {
-			name,
-			version,
-			updated: false,
-		};
-	}
-
-	await download(name, version, source, url, temporaryDir, debugChannel);
-
-	return {
-		name,
-		version,
-		updated: true,
-	};
-} // }}}
-
-function getReleasesUrl(extensionName: string, source: GitHub | undefined): string { // {{{
+export function getReleasesUrl(extensionName: string, source: GitHub | undefined): string { // {{{
 	if(source?.owner) {
 		return `https://api.github.com/repos/${source.owner}/${extensionName}/releases`;
 	}
@@ -131,7 +10,7 @@ function getReleasesUrl(extensionName: string, source: GitHub | undefined): stri
 	}
 } // }}}
 
-function getHeaders(source: GitHub | undefined): {} | undefined { // {{{
+export function getHeaders(source: GitHub | undefined): {} | undefined { // {{{
 	if(source?.token) {
 		let token: string | undefined = '';
 

--- a/src/utils/dispatch-install.ts
+++ b/src/utils/dispatch-install.ts
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 import { installFileSystem } from '../sources/filesystem';
+import { installForgejo } from '../sources/forgejo';
 import { installGitHub } from '../sources/github';
 import { installMarketplace } from '../sources/marketplace';
 import { InstallResult, Source } from './types';
@@ -14,6 +15,10 @@ export async function dispatchInstall(extensionName: string, extensionVersion: s
 
 		if(source.type === 'file') {
 			result = await installFileSystem(extensionName, extensionVersion, source, enabled, debugChannel);
+		}
+
+		if(source.type === 'forgejo') {
+			result = await installForgejo(extensionName, extensionVersion, source, temporaryDir, enabled, debugChannel);
 		}
 
 		if(source.type === 'github') {

--- a/src/utils/dispatch-install.ts
+++ b/src/utils/dispatch-install.ts
@@ -1,13 +1,14 @@
 import vscode from 'vscode';
 import { installFileSystem } from '../sources/filesystem';
-import { installForgejo } from '../sources/forgejo';
-import { installGitHub } from '../sources/github';
+import * as Forgejo from '../sources/forgejo';
+import * as Git from '../sources/git';
+import * as GitHub from '../sources/github';
 import { installMarketplace } from '../sources/marketplace';
 import { InstallResult, Source } from './types';
 
 export async function dispatchInstall(extensionName: string, extensionVersion: string | undefined, source: Source, sources: Record<string, Source> | undefined, temporaryDir: string, enabled: boolean, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> {
 	if(source === 'github') {
-		return installGitHub(extensionName, extensionVersion, undefined, temporaryDir, enabled, debugChannel);
+		return Git.install(extensionName, extensionVersion, undefined, GitHub, temporaryDir, enabled, debugChannel);
 	}
 
 	try {
@@ -18,11 +19,11 @@ export async function dispatchInstall(extensionName: string, extensionVersion: s
 		}
 
 		if(source.type === 'forgejo') {
-			result = await installForgejo(extensionName, extensionVersion, source, temporaryDir, enabled, debugChannel);
+			result = await Git.install(extensionName, extensionVersion, source, Forgejo, temporaryDir, enabled, debugChannel);
 		}
 
 		if(source.type === 'github') {
-			result = await installGitHub(extensionName, extensionVersion, source, temporaryDir, enabled, debugChannel);
+			result = await Git.install(extensionName, extensionVersion, source, GitHub, temporaryDir, enabled, debugChannel);
 		}
 
 		if(source.type === 'marketplace') {

--- a/src/utils/dispatch-update.ts
+++ b/src/utils/dispatch-update.ts
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 import { updateFileSystem } from '../sources/filesystem';
+import { updateForgejo } from '../sources/forgejo';
 import { updateGitHub } from '../sources/github';
 import { updateMarketplace } from '../sources/marketplace';
 import { Source, UpdateResult } from './types';
@@ -11,6 +12,10 @@ export async function dispatchUpdate(extensionName: string, currentVersion: stri
 
 	if(source.type === 'file') {
 		return updateFileSystem(extensionName, currentVersion, source, debugChannel);
+	}
+
+	if(source.type === 'forgejo') {
+		return updateForgejo(extensionName, currentVersion, source, temporaryDir, debugChannel);
 	}
 
 	if(source.type === 'github') {

--- a/src/utils/dispatch-update.ts
+++ b/src/utils/dispatch-update.ts
@@ -1,13 +1,14 @@
 import vscode from 'vscode';
 import { updateFileSystem } from '../sources/filesystem';
-import { updateForgejo } from '../sources/forgejo';
-import { updateGitHub } from '../sources/github';
+import * as Forgejo from '../sources/forgejo';
+import * as Git from '../sources/git';
+import * as GitHub from '../sources/github';
 import { updateMarketplace } from '../sources/marketplace';
 import { Source, UpdateResult } from './types';
 
 export async function dispatchUpdate(extensionName: string, currentVersion: string, source: Source, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<UpdateResult> {
 	if(source === 'github') {
-		return updateGitHub(extensionName, currentVersion, undefined, temporaryDir, debugChannel);
+		return Git.update(extensionName, currentVersion, undefined, GitHub, temporaryDir, debugChannel);
 	}
 
 	if(source.type === 'file') {
@@ -15,11 +16,11 @@ export async function dispatchUpdate(extensionName: string, currentVersion: stri
 	}
 
 	if(source.type === 'forgejo') {
-		return updateForgejo(extensionName, currentVersion, source, temporaryDir, debugChannel);
+		return Git.update(extensionName, currentVersion, source, Forgejo, temporaryDir, debugChannel);
 	}
 
 	if(source.type === 'github') {
-		return updateGitHub(extensionName, currentVersion, source, temporaryDir, debugChannel);
+		return Git.update(extensionName, currentVersion, source, GitHub, temporaryDir, debugChannel);
 	}
 
 	if(source.type === 'marketplace') {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -23,6 +23,14 @@ export type FileSystem = {
 	fallback?: string;
 };
 
+export type Forgejo = {
+	type: 'forgejo';
+	serviceUrl: string;
+	owner: string;
+	token?: string;
+	fallback?: string;
+};
+
 export type GitHub = {
 	type: 'github';
 	owner?: string;
@@ -46,7 +54,7 @@ export type MarketPlace = {
 	throttle: number;
 };
 
-export type Source = FileSystem | GitHub | MarketPlace | 'github';
+export type Source = FileSystem | Forgejo | GitHub | MarketPlace | 'github';
 
 export type UpdateResult = string | { name: string; version: string; updated: boolean } | undefined;
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -26,7 +26,7 @@ export type FileSystem = {
 export type Forgejo = {
 	type: 'forgejo';
 	serviceUrl: string;
-	owner: string;
+	owner?: string;
 	token?: string;
 	fallback?: string;
 };
@@ -36,6 +36,12 @@ export type GitHub = {
 	owner?: string;
 	token?: string;
 	fallback?: string;
+};
+
+export type GitService = Forgejo | GitHub;
+export type GitConfig = {
+	getHeaders(source: GitService | undefined): {} | undefined;
+	getReleasesUrl(extensionName: string, source: GitService | undefined): string;
 };
 
 export type InstallResult = { name: string; version: string; enabled: boolean } | undefined;


### PR DESCRIPTION
Add support for self-hosted Forgejo source, based on the existing GitHub source

`source.serviceUrl` is required, and expects the URL of the Forgejo API (ie `https://forgejo.myserver.com/api/v1`).