### PR TITLE
feat(git): better match using release name and detecting platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,18 @@ For an extension named: `"mfs:extXYZ"`, it will for the files:
 - `~/my-extensions/extXYZ-<version>.vsix`
 - `~/my-extensions/extXYZ/extXYZ-<version>.vsix`
 
-### github
+### git
+
+#### Syntax
+
+Whether you use GitHub or Forgejo, a release can possibly contain multiple extensions and/or versions.
+
+If no version is specified (`github:<username>/<project>@<version>`), then the manager will select the latest.
+If the release contains multiple extensions and none are specified, it will select the first one.
+
+You can select the wanted extension like `github:<username>/<project>!<extension>` (`github:<username>/<project>!<extension>@<version>`).
+
+#### GitHub
 
 `github` is a built-in source (no configuration required) and will install extensions from the GitHub release pages.
 
@@ -235,7 +246,7 @@ You can access your private repositories by giving an access token. You can spec
 }
 ```
 
-### forgejo
+#### Forgejo
 
 `forgejo` is a built-in source and will install extensions from the Forgejo release pages.
 
@@ -249,42 +260,6 @@ You can access your private repositories by giving an access token. You can spec
     },
     "vsix.extensions": [
         "mfj:<username>/<project>",
-    ],
-}
-```
-
-#### Private repository
-
-You can access your private repositories by giving an access token. You can specify an environment variable to read it from.
-
-```jsonc
-{
-    "vsix.sources": {
-        "mfj": {
-            "type": "forgejo",
-            "serviceUrl": "https://forgejo.myserver.com/api/v1",
-            "token": "env:MY_TOKEN",
-        },
-    },
-    "vsix.extensions": [
-        "mfj:<username>/<project>",
-    ],
-}
-```
-
-#### Owner
-
-```jsonc
-{
-    "vsix.sources": {
-       "mfj": {
-            "type": "forgejo",
-            "serviceUrl": "https://forgejo.myserver.com/api/v1",
-            "owner": "<username>",
-        },
-    },
-    "vsix.extensions": [
-        "mfj:<project>",
     ],
 }
 ```

--- a/src/commands/install-extensions.ts
+++ b/src/commands/install-extensions.ts
@@ -111,7 +111,13 @@ async function installExtensionWithSource(metadata: Metadata, sources: Record<st
 			}
 
 			if(update) {
-				const result = await dispatchUpdate(metadata.fullName, currentVersion, source, TEMPORARY_DIR, debugChannel);
+				if(currentVersion === metadata.targetVersion) {
+					debugChannel?.appendLine('expected version is already installed');
+					return true;
+				}
+
+				const result = await dispatchUpdate(metadata, currentVersion, source, TEMPORARY_DIR, debugChannel);
+
 				if(!result) {
 					extensionManager.setInstalled(metadata.fullName, currentVersion);
 
@@ -146,7 +152,7 @@ async function installExtensionWithSource(metadata: Metadata, sources: Record<st
 		return true;
 	}
 
-	const result = await dispatchInstall(metadata.fullName, metadata.version, source, sources, TEMPORARY_DIR, metadata.enabled, debugChannel);
+	const result = await dispatchInstall(metadata, source, sources, TEMPORARY_DIR, debugChannel);
 
 	if(result) {
 		await extensionManager.addInstalled(result.name, result.version, result.enabled, debugChannel);

--- a/src/commands/update-extensions.ts
+++ b/src/commands/update-extensions.ts
@@ -64,8 +64,8 @@ async function updateExtension(data: unknown, sources: Record<string, Source> | 
 async function updateExtensionWithSource(extension: Metadata, sources: Record<string, Source> | undefined, groups: Record<string, unknown[]> | undefined, extensionManager: ExtensionManager, debugChannel: vscode.OutputChannel | undefined): Promise<void> { // {{{
 	debugChannel?.appendLine(`updating extension: ${extension.source!}:${extension.fullName}`);
 
-	if(extension.version) {
-		debugChannel?.appendLine(`has specific version: ${extension.version}`);
+	if(extension.targetVersion) {
+		debugChannel?.appendLine(`has specific version: ${extension.targetVersion}`);
 		return;
 	}
 
@@ -86,7 +86,12 @@ async function updateExtensionWithSource(extension: Metadata, sources: Record<st
 		return;
 	}
 
-	const result = await dispatchUpdate(extension.fullName, currentVersion, source, TEMPORARY_DIR, debugChannel);
+	if(currentVersion === extension.targetVersion) {
+		debugChannel?.appendLine('expected version is already installed');
+		return;
+	}
+
+	const result = await dispatchUpdate(extension, currentVersion, source, TEMPORARY_DIR, debugChannel);
 
 	if(!result) {
 		extensionManager.setInstalled(extension.fullName, currentVersion);

--- a/src/sources/filesystem.ts
+++ b/src/sources/filesystem.ts
@@ -4,7 +4,7 @@ import globby from 'globby';
 import semver from 'semver';
 import untildify from 'untildify';
 import vscode from 'vscode';
-import type { FileSystem, InstallResult } from '../utils/types.js';
+import type { FileSystem, InstallResult, Metadata } from '../utils/types.js';
 
 async function find(root: string, extensionName: string, extensionVersion: string | undefined, debugChannel: vscode.OutputChannel | undefined): Promise<{ version: string; file: string }> { // {{{
 	const files = await globby('*.vsix', {
@@ -78,14 +78,14 @@ async function search(extensionName: string, extensionVersion: string | undefine
 	};
 } // }}}
 
-export async function installFileSystem(extensionName: string, extensionVersion: string | undefined, source: FileSystem, enabled: boolean, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> { // {{{
+export async function installFileSystem({ fullName: extensionName, targetVersion, enabled }: Metadata, source: FileSystem, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> { // {{{
 	const root = untildify(source.path);
 
 	if(!fse.existsSync(root)) {
 		return;
 	}
 
-	const { file, version } = await search(extensionName, extensionVersion, root, debugChannel);
+	const { file, version } = await search(extensionName, targetVersion, root, debugChannel);
 
 	if(file) {
 		debugChannel?.appendLine(`installing: ${file}`);
@@ -96,7 +96,7 @@ export async function installFileSystem(extensionName: string, extensionVersion:
 	}
 } // }}}
 
-export async function updateFileSystem(extensionName: string, currentVersion: string, source: FileSystem, debugChannel: vscode.OutputChannel | undefined): Promise<string | undefined> { // {{{
+export async function updateFileSystem({ fullName: extensionName }: Metadata, currentVersion: string, source: FileSystem, debugChannel: vscode.OutputChannel | undefined): Promise<string | undefined> { // {{{
 	const root = untildify(source.path);
 
 	if(!fse.existsSync(root)) {

--- a/src/utils/dispatch-install.ts
+++ b/src/utils/dispatch-install.ts
@@ -4,30 +4,30 @@ import * as Forgejo from '../sources/forgejo.js';
 import * as Git from '../sources/git.js';
 import * as GitHub from '../sources/github.js';
 import { installMarketplace } from '../sources/marketplace.js';
-import type { InstallResult, Source } from './types.js';
+import type { InstallResult, Metadata, Source } from './types.js';
 
-export async function dispatchInstall(extensionName: string, extensionVersion: string | undefined, source: Source, sources: Record<string, Source> | undefined, temporaryDir: string, enabled: boolean, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> {
+export async function dispatchInstall(metadata: Metadata, source: Source, sources: Record<string, Source> | undefined, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<InstallResult> {
 	if(source === 'github') {
-		return Git.install(extensionName, extensionVersion, undefined, GitHub, temporaryDir, enabled, debugChannel);
+		return Git.install(metadata, undefined, GitHub, temporaryDir, debugChannel);
 	}
 
 	try {
 		let result: InstallResult;
 
 		if(source.type === 'file') {
-			result = await installFileSystem(extensionName, extensionVersion, source, enabled, debugChannel);
+			result = await installFileSystem(metadata, source, debugChannel);
 		}
 
 		if(source.type === 'forgejo') {
-			result = await Git.install(extensionName, extensionVersion, source, Forgejo, temporaryDir, enabled, debugChannel);
+			result = await Git.install(metadata, source, Forgejo, temporaryDir, debugChannel);
 		}
 
 		if(source.type === 'github') {
-			result = await Git.install(extensionName, extensionVersion, source, GitHub, temporaryDir, enabled, debugChannel);
+			result = await Git.install(metadata, source, GitHub, temporaryDir, debugChannel);
 		}
 
 		if(source.type === 'marketplace') {
-			result = await installMarketplace(extensionName, extensionVersion, source, sources!, temporaryDir, enabled, debugChannel);
+			result = await installMarketplace(metadata, source, sources!, temporaryDir, debugChannel);
 		}
 
 		if(result) {
@@ -42,9 +42,9 @@ export async function dispatchInstall(extensionName: string, extensionVersion: s
 		const newSource = sources![source.fallback];
 
 		if(newSource) {
-			debugChannel?.appendLine(`installing extension: ${source.fallback}:${extensionName}`);
+			debugChannel?.appendLine(`installing extension: ${source.fallback}:${metadata.fullName}`);
 
-			return dispatchInstall(extensionName, extensionVersion, newSource, sources, temporaryDir, enabled, debugChannel);
+			return dispatchInstall(metadata, newSource, sources, temporaryDir, debugChannel);
 		}
 	}
 }

--- a/src/utils/dispatch-update.ts
+++ b/src/utils/dispatch-update.ts
@@ -4,26 +4,26 @@ import * as Forgejo from '../sources/forgejo.js';
 import * as Git from '../sources/git.js';
 import * as GitHub from '../sources/github.js';
 import { updateMarketplace } from '../sources/marketplace.js';
-import type { Source, UpdateResult } from './types.js';
+import type { Metadata, Source, UpdateResult } from './types.js';
 
-export async function dispatchUpdate(extensionName: string, currentVersion: string, source: Source, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<UpdateResult> {
+export async function dispatchUpdate(extension: Metadata, currentVersion: string, source: Source, temporaryDir: string, debugChannel: vscode.OutputChannel | undefined): Promise<UpdateResult> {
 	if(source === 'github') {
-		return Git.update(extensionName, currentVersion, undefined, GitHub, temporaryDir, debugChannel);
+		return Git.update(extension, currentVersion, undefined, GitHub, temporaryDir, debugChannel);
 	}
 
 	if(source.type === 'file') {
-		return updateFileSystem(extensionName, currentVersion, source, debugChannel);
+		return updateFileSystem(extension, currentVersion, source, debugChannel);
 	}
 
 	if(source.type === 'forgejo') {
-		return Git.update(extensionName, currentVersion, source, Forgejo, temporaryDir, debugChannel);
+		return Git.update(extension, currentVersion, source, Forgejo, temporaryDir, debugChannel);
 	}
 
 	if(source.type === 'github') {
-		return Git.update(extensionName, currentVersion, source, GitHub, temporaryDir, debugChannel);
+		return Git.update(extension, currentVersion, source, GitHub, temporaryDir, debugChannel);
 	}
 
 	if(source.type === 'marketplace') {
-		return updateMarketplace(extensionName, currentVersion, source, temporaryDir, debugChannel);
+		return updateMarketplace(extension, currentVersion, source, temporaryDir, debugChannel);
 	}
 }

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -39,16 +39,17 @@ function parseString(data: string, enabled: boolean | null, result: Metadata[]):
 	}
 
 	if(data.includes(':')) {
-		const matches = /^([^:]*):(.*?)(?:@(\d+\.\d+\.\d+))?$/.exec(data);
+		const matches = /^([^:]*):(.*?)(?:!([^@]+))?(?:@(\d+\.\d+\.\d+))?$/.exec(data);
 
 		if(matches) {
-			const [, source, fullName, version] = matches;
+			const [, source, fullName, target, version] = matches;
 
 			result.push({
 				kind: 'extension',
 				source,
 				fullName,
-				version,
+				targetName: target,
+				targetVersion: version,
 				enabled,
 			});
 		}
@@ -62,7 +63,7 @@ function parseString(data: string, enabled: boolean | null, result: Metadata[]):
 			result.push({
 				kind: 'extension',
 				fullName,
-				version,
+				targetVersion: version,
 				enabled,
 			});
 		}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,9 +1,10 @@
 export type Metadata = {
 	kind: MetadataKind;
-	fullName: string;
-	version?: string;
-	source?: string;
 	enabled: boolean;
+	fullName: string;
+	source?: string;
+	targetName?: string;
+	targetVersion?: string;
 };
 
 export type MetadataKind = 'extension' | 'group';


### PR DESCRIPTION
This PR improves the matching of assets by:
- detecting the version in the release name (so not needed in the asset name)
- detecting the platform
- allowing to pass the extension name as an asset prefix

Fixing the following:
```
"github:whitphx/vscode-emacs-mcx",
"github:Myriad-Dreamin/tinymist",
"github:Myriad-Dreamin/tinymist!typst-preview",
```

References:
- #31